### PR TITLE
fixed URL problems

### DIFF
--- a/standard/clause_7_core.adoc
+++ b/standard/clause_7_core.adoc
@@ -534,9 +534,9 @@ See <<http_status_codes>> for general guidance.
 
 The third part is about query parameters:
 
-*   http://acme.com/oapi/collections/%7Bcollectionid%7D/coverage?SUBSET=Lat(40,50)&SUBSET=Long(10,20)[http://acme.com/oapi/collections/{collectionid}/coverage?SUBSET=Lat(40]  -- returns a coverage cutout between (40,10) and (50,20), as multipart coverage
+*   http://acme.com/oapi/collections/%7Bcollectionid%7D/coverage?SUBSET=Lat(40,50)&SUBSET=Long(10,20)[http://acme.com/oapi/collections/{collectionid}/coverage?SUBSET=Lat(40_50)&SUBSET=Long(10_20)]  -- returns a cutout from the coverage identified with extent between corner coordinates (40,10) and (50,20) (note: replace the _ in the URL by a comma character - an adoc issue)
 
-*   http://acme.com/oapi/collections/%7Bcollectionid%7D/coverage/rangeset?SUBSET=Lat(40,50)&SUBSET=Long(10,20)[http://acme.com/oapi/collections/{collectionid}/coverage/rangeset?SUBSET=Lat(40]  -- returns a coverage cutout between (40,10) and (50,20), in the coverage’s Native Format
+*   http://acme.com/oapi/collections/%7Bcollectionid%7D/coverage/rangeset?SUBSET=Lat(40,50)&SUBSET=Long(10,20)[http://acme.com/oapi/collections/{collectionid}/coverage/rangeset?SUBSET=Lat(40_50)&SUBSET=Long(10_20)]  -- returns the range set of a coverage cutout between (40,10) and (50,20), in the coverage’s Native Format; no domain set, range type, and metadata will be returned (note: replace the _ in the URL by a comma character - an adoc issue)
 
 *   http://acme.com/oapi/collections/%7Bcollectionid%7D/coverage?SUBSET=time(%222019-03-27%22)[http://acme.com/oapi/collections/{collectionid}/coverage?SUBSET=time("2019-03-27")]  -- returns a coverage slice at the timestamp given (in case the coverage is Lat/Long/time the result will be a 2D image)
 


### PR DESCRIPTION
adoc when seeing a "," in a URL interprets the next "=" - inour case, syntax is not recognized by adoc so the remaining part of the URL is suppressed, making it incomplete. Found no way to substitute silently, therefore an explicit change has been implemented.