### PR TITLE
std/req/geodata-coverage; 6-overview; 7-geodata-coverage; README: Upd…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It integrates with the OGC API family of standards through [OGC API - Common](ht
 
 Resource path: `{datasetAPI}/`
 
-Relation type: `ogc:common:dataset`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/dataset`
 
 HTTP methods: `GET`
 
@@ -107,7 +107,7 @@ Lists the collections intersecting with the New Zealand economic zone (any time,
 
 Resource path: `{datasetAPI}/collections/{collectionId}`
 
-Relation type: `ogc:common:collection`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/collection`
 
 HTTP methods: `GET`
 
@@ -135,7 +135,7 @@ Resource path: `{datasetAPI}/collections/{coverageId}`
 
 NOTE: `{collectionId}` is replaced here by `{coverageId}` as extensions specific to coverages are described
 
-Relation type: `ogc:common:collection`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/collection`
 
 HTTP methods: `GET`
 
@@ -147,10 +147,15 @@ but the OGC API - Coverages Part 1: Core standard further extends it with the fo
 - a `RangeType` describing the data values semantics (their components and data type),
 - a `DomainSet` describing the domain set (the detailed n-dimensional space covered by the data).
 
-In a JSON representation of this resource, both `RangeType` and `DomainSet` properties are encoded as [CIS JSON](https://docs.opengeospatial.org/is/09-146r6/09-146r6.html#46).
+In a JSON representation of this resource, both `RangeType` and `DomainSet` properties are at least available encoded as [CIS JSON](https://docs.opengeospatial.org/is/09-146r6/09-146r6.html#46).
 
-Both of these properties are required for conforming to coverage access for that collection,
-unless they are defined as separate resources and linked using the associated relation type within the `links` property.
+Both of these properties are required for conforming to coverage access for that collection, unless they are available as separate resources.
+
+Whether they are embedded or a separate resources, links using their respective relation type (`http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype` or
+`http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset`) must be present within the `links` property.
+If the properties are embedded, the links will be relative and point directly to the property using `#` e.g.,
+`#DomainSet` and `#RangeType`.
+
 A good reason to define them as separate resources would be if they are complex and consist of a sizable amount of data.
 
 See the [range type](#rangeTypeExample) and [domain set](#domainSetExample) resources below for examples encoding them as CIS JSON.
@@ -164,7 +169,7 @@ Resource path: `{datasetAPI}/collections/{coverageId}/coverage`
 
 NOTE: though this path should exist, a client should not rely on it as additional representations for this resource may reside elsewhere, e.g. /coverage.tiff or /coverage?f=tiff
 
-Relation type: `ogc:coverage:coverage`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/coverage`
 
 HTTP methods: `GET`
 
@@ -199,9 +204,9 @@ Retrieve the subset of the coverage between 40 and 50 degrees North, 10 and 20 d
 
 Resource path: `{datasetAPI}/collections/{coverageId}/coverage/rangeset`
 
-NOTE: this path is not fixed and not required
+NOTE: this path is not fixed and not required (follow the link)
 
-Relation type: `ogc:coverage:rangeset`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/coverage-rangeset`
 
 HTTP methods: `GET`
 
@@ -234,9 +239,9 @@ Example CIS JSON rangeSet encoding:
 
 Resource path: `{datasetAPI}/collections/{coverageId}/coverage/rangetype`
 
-NOTE: this path is not fixed and may not exist
+NOTE: this path is not fixed and may not exist (follow the link)
 
-Relation type: `ogc:coverage:rangetype`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype`
 
 HTTP methods: `GET`
 
@@ -247,6 +252,7 @@ Alternative JSON encodings such as CoverageJSON must be differentiated by using 
 
 If provided, returns only the range type of the coverage, i.e. the data values semantics (their components and data type).
 A CIS JSON encoding of this resource is required, but may be embedded within the Coverage description resource as the value of the `RangeType` property.
+In that case, a link will still exist pointing to `#RangeType`
 A reason to make it a separate resource is if the range type is very complex and consists of a sizable amount of data.
 
 <a name="rangeTypeExample"></a>
@@ -272,9 +278,9 @@ Example CIS JSON range type encoding:
 
 Resource path: `{datasetAPI}/collections/{coverageId}/coverage/domainset`
 
-NOTE: this path is not fixed and may not exist
+NOTE: this path is not fixed and may not exist (follow the link)
 
-Relation type: `ogc:coverage:domainset`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset`
 
 HTTP methods: `GET`
 
@@ -285,6 +291,7 @@ Alternative JSON encodings such as CoverageJSON must be differentiated by using 
 
 If provided, returns only the domain set of the coverage (the detailed n-dimensional space covered by the data).
 A CIS JSON encoding of this resource is required, but may be embedded within the Coverage description resource as the value of the `DomainSet` property.
+In that case, a link will still exist pointing to `#DomainSet`
 A reason to make it a separate resource is if the domain set is very complex and consists of a sizable amount of data,
 and optionally if the API supports subsetting the domain set itself.
 
@@ -332,7 +339,7 @@ Resource path: `{datasetAPI}/collections/{coverageId}/coverage/metadata`
 
 NOTE: this path is not fixed and may not exist
 
-Relation type: `ogc:coverage:metadata`
+Relation type: `http://www.opengis.net/def/rel/ogc/1.0/coverage-metadata`
 
 HTTP methods: `GET`
 

--- a/standard/clause_6_overview.adoc
+++ b/standard/clause_6_overview.adoc
@@ -15,7 +15,7 @@ Resources exposed through an OGC API may be accessed through a Universal Resourc
 * Access Paths: Unique paths to Resources
 * Query: Parameters to adjust the representation of a Resource or Resources like encoding format or subsetting
 
-Access Paths are used to build resource identifiers. It is recommended, but not required, that these paths 
+Access Paths are used to build resource identifiers. It is recommended, but not required, that these paths
 
 Most resources are also accessible through links on previously accessed resources. Unique relation types are used for each resource.
 
@@ -33,11 +33,11 @@ Most resources are also accessible through links on previously accessed resource
 |<<collections,{datasetAPI}/collections>> |`data` |The list off all collections available, some or all of which may be accessible using this Coverage API. Each of these collection objects take the same form as that of the collection resource object described immediately below.
 |<<collectionInfo,{datasetAPI}/collections/{coverageId}>> |`ogc:common:collection` |resource corresponding to the collection with the unique identifier `{coverageId}`, which may be accessible as a coverage. The resource will describe key elements such as an `id`, `title`, `description`, available `crs` and `extent` (the coverage envelope) as well as links to resources pertaining to this collection. For coverages, it will either embed or link to a CIS JSON encoding of both the range type and the domain set. It is comparable to a WCS *_DescribeCoverage_* response, with the exception that the range type and domain set may have to be retrieved separately by following a link to accommodate the case where they may be considerably large, and the domain set may support query parameters to subset it.
 3+^|**Coverages**
-|<<coverage-clause,{datasetAPI}/collections/{coverageId}/coverage>> |`ogc:coverage:coverage` |returns the coverage including all of its components (domain set, range type, range set and metadata), to the extent that it is supported by the selected representation (see format encoding for ways to retrieve in specific formats). It is comparable to a WCS *_GetCoverage_* response.
-|<<coverage-rangeset-clause,{datasetAPI}/collections/{coverageId}/coverage/rangeset>> |`ogc:coverage:rangeset` |if supported by the service and by the selected representation, returns only the coverage's range set, i.e., the actual values in the selected representation without any accompanying description or extra information.
-|<<coverage-rangetype-clause,{datasetAPI}/collections/{coverageId}/coverage/rangetype>> |`ogc:coverage:rangetype` |if available separately from the collection resource, returns the coverage's range type information, i.e., a description of the data semantics (their components and data type).
-|<<coverage-domainset-clause,{datasetAPI}/collections/{coverageId}/coverage/domainset>> |`ogc:coverage:domainset` |if available separately from the collection resource, returns the coverage's domain set definition (the detailed n-dimensional space covered by the data).
-|<<coverage-metadata-clause,{datasetAPI}/collections/{coverageId}/coverage/metadata>> |`ogc:coverage:metadata` |if available, returns the associated coverage metadata as defined by the CIS model, which may be e.g. domain specific metadata.
+|<<coverage-clause,{datasetAPI}/collections/{coverageId}/coverage>> |`http://www.opengis.net/def/rel/ogc/1.0/coverage` |returns the coverage including all of its components (domain set, range type, range set and metadata), to the extent that it is supported by the selected representation (see format encoding for ways to retrieve in specific formats). It is comparable to a WCS *_GetCoverage_* response.
+|<<coverage-rangeset-clause,{datasetAPI}/collections/{coverageId}/coverage/rangeset>> |`http://www.opengis.net/def/rel/ogc/1.0/coverage-rangeset` |if supported by the service and by the selected representation, returns only the coverage's range set, i.e., the actual values in the selected representation without any accompanying description or extra information.
+|<<coverage-rangetype-clause,{datasetAPI}/collections/{coverageId}/coverage/rangetype>> |`http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype` |if available separately from the collection resource, returns the coverage's range type information, i.e., a description of the data semantics (their components and data type).
+|<<coverage-domainset-clause,{datasetAPI}/collections/{coverageId}/coverage/domainset>> |`http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset` |if available separately from the collection resource, returns the coverage's domain set definition (the detailed n-dimensional space covered by the data).
+|<<coverage-metadata-clause,{datasetAPI}/collections/{coverageId}/coverage/metadata>> |`http://www.opengis.net/def/rel/ogc/1.0/coverage-metadata` |if available, returns the associated coverage metadata as defined by the CIS model, which may be e.g. domain specific metadata.
 |===
 
 Where:

--- a/standard/clause_7_geodata_coverage.adoc
+++ b/standard/clause_7_geodata_coverage.adoc
@@ -273,7 +273,13 @@ A coverage containing the `DomainSet`, `RangeType`, `RangeSet`, and `Metadata`  
 * The relative path `/coverage`
 * The link relation `ogc:coverage:coverage`
 
-The `DomainSet` and `RangeType` are either defined as properties of the `/collections/{coverageid}` resource, or linked using specific relation types to their own resource.
+The `DomainSet` and `RangeType` are accessible from resources linked by links within the `/collections/{coverageid}` resource,
+using the relation types `http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset` and
+`http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype`, respectively.
+Those links may either point to separate resource, in which case the recommended paths are `/collections/{coverageid}/coverage/domainset` and
+`/collections/{coverageid}/coverage/rangetype`, or point to the coverage description resource itself the domain set and/or range type are
+embedded. In the latter case those links will point specifically to properties using `#`, e.g.,
+`#domainset` and `#rangetype`.
 
 The `RangeSet` may be available as its own resource as well, if supported by the selected representation (format).
 

--- a/standard/requirements/geodata-coverage/REQ_domainset-op.adoc
+++ b/standard/requirements/geodata-coverage/REQ_domainset-op.adoc
@@ -2,7 +2,10 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/geodata-coverage/domainset-op*
-^|A |If the API does not include a "DomainSet" property within the coverage (collection) resource, it The API SHALL support the HTTP GET operation at the path `/collections/{coverageid}/coverage/domainset`.
+^|A |The API SHALL include a link with the relation type `http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset` within the links of the
+coverage (collection) resource, to a resource supporting the HTTP GET operation and returning a CIS JSON representation including a `DomainSet` property.
+This link can either be a link to a separate resource (e.g., recommended path `/collections/{coverageid}/coverage/domainset`) or a link to the coverage
+resource itself pointing to the property with `#` e.g., `#DomainSet`.
 
 * `coverageid` is the local identifier for a `Coverage`. It serves the same role and is subject to the same requirements as the `collectionid` parameter defined in API-Common.
 |===

--- a/standard/requirements/geodata-coverage/REQ_rangetype-op.adoc
+++ b/standard/requirements/geodata-coverage/REQ_rangetype-op.adoc
@@ -2,7 +2,10 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/geodata-coverage/rangetype-op*
-^|A |If the API does not include a "RangeType" property within the coverage (collection) resource, it SHALL support the HTTP GET operation at the path `/collections/{coverageid}/coverage/rangetype`.
+^|A |The API SHALL include a link with the relation type `http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype` within the links of the
+coverage (collection) resource, to a resource supporting the HTTP GET operation and returning a CIS JSON representation including a `RangeType` property.
+This link can either be a link to a separate resource (e.g., recommended path `/collections/{coverageid}/coverage/rangetype`) or a link to the coverage
+resource itself pointing to the property with `#` e.g., `#RangeType`.
 
 * `coverageid` is the local identifier for a `Coverage`. It serves the same role and is subject to the same requirements as the `collectionid` parameter defined in API-Common.
 |===


### PR DESCRIPTION
…ated to reflect decision for #64

- A link to both DomainSet and RangeType is always present in /collections/{collectionId} resource links
- That link may point to a separate resource
  (e.g. /collections/{collectionId}/coverage/domainset or /collections/{collectionId}/coverage/rangetype)
- That link may also point to a specific property of the collection resource itself
   e.g. /collections/{collectionId}#DomainSet or /collections/{collectionId}#RangeType
- Updated to the latest relation types from the code sprint, following OGC NA guidance that URIs should be URLs (possibly still under discussion)