### PR TITLE
Fixed broken links and applied scaling and subset fixes

### DIFF
--- a/standard/clause_9_coverage_subset_and_scaling.adoc
+++ b/standard/clause_9_coverage_subset_and_scaling.adoc
@@ -25,7 +25,7 @@ include::requirements/requirements_class_coverage_scaling.adoc[]
 
 The scaling parameters are defined in the following Requirement:
 
-include::requirements/coverage-subset/REQ_cov-scaling-definition.adoc[]
+include::requirements/coverage-scaling/REQ_cov-scaling-definition.adoc[]
 
 The results of using a scaling parameter are defined by the following Requirement:
 

--- a/standard/examples/JSON/collection_info_example.json
+++ b/standard/examples/JSON/collection_info_example.json
@@ -3,19 +3,34 @@
     "title": "Bonn Germany",
     "description": "Image over the city of Bonn.",
     "extent": {
-        "spatial": [ 7.01, 50.63, 7.22, 50.78 ],
-        "temporal": [ "2010-02-15T12:34:56Z", "2018-03-18T12:11:00Z" ]
-      },
-    "itemType": "coverage",
+        "spatial": {
+           "bbox" : [ [ 7.01, 50.63, 7.22, 50.78 ] ],
+           "crs" : "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        "temporal": {
+           "interval" : [ [ "2010-02-15T12:34:56Z", "2018-03-18T12:11:00Z" ] ]
+        }
+    },
     "CRS": [
         "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
         "http://www.opengis.net/def/crs/EPSG/0/4326"
     ],
-    "domainSet": {"$href": "http://data.example.org/collections/CIS123456789/coverages/domainSet"},      
-    "rangeType": {"$href": "http://data.example.org/collections/CIS123456789/coverages/rangeType"},
     "links": [
-      { "href": "http://data.example.org/collections/CIS123456789/coverages",
-        "rel": "items", "type": "application/json",
-        "title": "CIS Image" }
-     ]
+      {
+        "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+        "type": "application/json",
+        "title": "CIS Image",
+        "href": "http://data.example.org/collections/CIS123456789/coverage"
+      },
+      {
+         "rel" : "http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset",
+         "type" : "application/json",
+         "href": "http://data.example.org/collections/CIS123456789/coverage/domainSet"
+      },
+      {
+         "rel" : "http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype",
+         "type" : "application/json",
+         "href": "http://data.example.org/collections/CIS123456789/coverage/rangeType"
+      }
+    ]
 }

--- a/standard/examples/examples_scaling.adoc
+++ b/standard/examples/examples_scaling.adoc
@@ -2,5 +2,5 @@
 
 * {datasetAPI}/collections/{coverageid}/coverage?scaleSize=Lat(300),Lon(400) -- returns the entire coverage re-scaled to 300 pixels along its latitude axis, and 400 samples along its longitude axis in the negotiated format
 * {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=Lat(40:50),Lon(10:20)&scaleSize=Lat(300),Lon(400) -- returns a coverage cutout (sample values only) between (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20), re-scaled to 300 pixels along its latitude axis, and 400 samples along its longitude axis in the negotiated format
-* {datasetAPI}/collections/{coverageid}/coverage?scaleFactor=1.5 -- returns a coverage re-scaled so as to contain 1.5 timess less sample values along all of its axes
-* {datasetAPI}/collections/{coverageid}/coverage?scaleAxes=Lat(2) -- returns a coverage re-scaled so as to contain 2 timess less sample values along its latitude axis, and all original values along all its other dimensions
+* {datasetAPI}/collections/{coverageid}/coverage?scaleFactor=1.5 -- returns a coverage re-scaled so as to contain 1.5 times less sample values along all of its axes
+* {datasetAPI}/collections/{coverageid}/coverage?scaleAxes=Lat(2) -- returns a coverage re-scaled so as to contain 2 times less sample values along its latitude axis, and all original values along all its other dimensions

--- a/standard/examples/examples_subsetting.adoc
+++ b/standard/examples/examples_subsetting.adoc
@@ -1,6 +1,10 @@
+These examples return a subset of a coverage in the negotiated format, including domain set, range type (and metadata if applicable) to the extent than they can be described in that format:
 
-* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=Lat(40:50),Lon(10:20) -- returns a coverage cutout (sample values only) between (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20), in the negotiated format
-* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=time("2019-03-27") -- returns a coverage slice (sample values only) at the timestamp given, with all data available in the other dimensions (in case the coverage is Lat/Lon/time the result will be a 2D image with its full Lat/Lon extent)
-* {datasetAPI}/collections/{coverageid}/coverage?subset=Lat(40:50),Lon(10:20) -- returns a cutout from the coverage identified with extent between corner coordinates (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20)
-* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=Lat(40:50),Lon(10:20)  -- returns the range set of a coverage cutout between (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20), in the negotiated format; no domain set, range type, or metadata will be returned
-* {datasetAPI}/collections/{coverageid}/coverage?subset=time("2019-03-27") -- returns a coverage slice at the timestamp given (in case the coverage is Lat/Lon/time the result will be a 2D image)
+* {datasetAPI}/collections/{coverageid}/coverage?subset=Lat(40:50),Lon(10:20) -- returns a cutout (trim) from the coverage for the extent between corner coordinates (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20)
+* {datasetAPI}/collections/{coverageid}/coverage?subset=time("2019-03-27") -- returns a coverage slice at the timestamp (if the coverage is has 2D spatial dimensions plus time, the result will be a 2D image with its full spatial extent)
+
+A `rangeset` resource, also supporting subsetting, may be available in some implementations, for some formats/media types.
+The following examples using this resource return only the sample values for a subset of a coverage in the negotiated format, without domain set, range type or metadata:
+
+* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=Lat(40:50),Lon(10:20)  -- returns a coverage cutout/trim between (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20)
+* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=time("2019-03-27") -- returns a coverage slice at the timestamp given, with all data available in the other dimensions (if the coverage is has 2D spatial dimensions plus time, the result will be a 2D image with its full spatial extent)

--- a/standard/openapi/schemas/common/collectionInfo.json
+++ b/standard/openapi/schemas/common/collectionInfo.json
@@ -13,9 +13,9 @@
         "description": {"type": "string"},
         "links": {
             "type": "array",
-            "items": {"$href": "link.json"}
+            "items": {"$ref": "link.json"}
         },
-        "extent": {"$href": "extent.json"},
+        "extent": {"$ref": "extent.json"},
         "itemType": {
             "type": "string",
             "default": "unknown"

--- a/standard/openapi/schemas/common/collections.json
+++ b/standard/openapi/schemas/common/collections.json
@@ -10,11 +10,11 @@
     "properties": {
         "links": {
             "type": "array",
-            "items": {"$href": "link.json"}
+            "items": {"$ref": "link.json"}
         },
         "collections": {
             "type": "array",
-            "items": {"$href": "collectionInfo.json"}
+            "items": {"$ref": "collectionInfo.json"}
         }
     }
 }

--- a/standard/openapi/schemas/common/landingPage.json
+++ b/standard/openapi/schemas/common/landingPage.json
@@ -16,7 +16,7 @@
         "links": {
             "description": "Links to the resources exposed through this API.",
             "type": "array",
-            "items": {"$href": "link.json"}
+            "items": {"$ref": "link.json"}
         }
     },
     "patternProperties": {

--- a/standard/openapi/schemas/coverage_collectionInfo.json
+++ b/standard/openapi/schemas/coverage_collectionInfo.json
@@ -16,9 +16,9 @@
         "description": {"type": "string"},
         "links": {
             "type": "array",
-            "items": {"$href": "link.json"}
+            "items": {"$ref": "link.json"}
         },
-        "extent": {"$href": "extent.json"},
+        "extent": {"$ref": "extent.json"},
         "itemType": {
             "type": "string",
             "default": "unknown"

--- a/standard/requirements/coverage-scaling/REQ_cov-scaling-definition.adoc
+++ b/standard/requirements/coverage-scaling/REQ_cov-scaling-definition.adoc
@@ -2,28 +2,26 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/coverage-scaling/definition*
-^|A |The operation SHALL support a parameter `scaleSize` with the following characteristics (using an Backus Naur Form (BNF) fragment):
+^|A |The operation SHALL support a parameter `scaleSize` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
 
-[source,BNF]
+[source,EBNF]
 ----
-  ScalingSpec:       scaleSize=axisName({number})[,axisName({nuber})]*
-  axisName:          {NCName}
+  ScalingSpec:       "scaleSize"=axisName({number})[,axisName({number})]*
+  axisName:          {text}
 
   Where:
-     {NCName} is an XML-style identifier not containing ":" (colon) characters,
      {number} is an integer or floating-point number, and
 
 ----
 ^|B |The operation SHALL support `scaleFactor` numeric parameter.
-^|C |The operation SHALL support a parameter `scaleAxes` with the following characteristics (using an Backus Naur Form (BNF) fragment):
+^|C |The operation SHALL support a parameter `scaleAxes` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
 
-[source,BNF]
+[source,EBNF]
 ----
-  ScalingSpec:       scaleAxes=axisName({number})[,axisName({nuber})]*
+  ScalingSpec:       "scaleAxes"=axisName({number})[,axisName({number})]*
   axisName:          {NCName}
 
   Where:
-     {NCName} is an XML-style identifier not containing ":" (colon) characters,
      {number} is an integer or floating-point number, and
 
 ^|D |The axis name SHALL be the same as one of the `axisLabels` defined in the DomainSet, and shall match the abbreviations defined by the CRS

--- a/standard/requirements/coverage-subset/REQ_cov-subset-definition.adoc
+++ b/standard/requirements/coverage-subset/REQ_cov-subset-definition.adoc
@@ -2,12 +2,12 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/coverage-subset/definition*
-^|A |The operation SHALL support a parameter `subset` with the following characteristics (using an Backus Naur Form (BNF) fragment):
+^|A |The operation SHALL support a parameter `subset` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
 
-[source,BNF]
+[source,EBNF]
 ----
-  SubsetSpec:        subset=axisName(intervalOrPoint)
-  axisName:          {NCName}
+  SubsetSpec:        "subset"=axisName(intervalOrPoint)
+  axisName:          {text}
   intervalOrPoint:   interval \| point
   interval:          low : high
   low:               point \| *
@@ -16,7 +16,6 @@
 
   Where:
      \" = double quote = ASCII code 0x42,
-     {NCName} is an XML-style identifier not containing ":" (colon) characters,
      {number} is an integer or floating-point number, and
      {text} is some general ASCII text (such as a time and date notation in ISO 8601).
 ----


### PR DESCRIPTION
- standard/clause_9_coverage_subset_and_scaling: Fixed broken link
- requirements/coverage-scaling; coverage-subset: Changed to EBNF; Removed mention of NCName and XML; Fixed nuber typo
- examples_subsetting.adoc: Removed duplicate examples; organized and improved descriptions for greater clarity
- examples_scaling.adoc: Fixed typos